### PR TITLE
Cleanup excessive commands from bootstrap

### DIFF
--- a/genesis/images/bootstrap.sh
+++ b/genesis/images/bootstrap.sh
@@ -62,5 +62,5 @@ curl --location --globoff 'http://10.20.0.2:11010/v1/hypervisors/' \
 
 sudo systemctl restart netfilter-persistent.service
 
-#Do bootstrap only once
+# Remove the cron job to ensure bootstrap runs only once
 sudo rm /etc/cron.d/core_bootstrap

--- a/genesis/images/bootstrap.sh
+++ b/genesis/images/bootstrap.sh
@@ -62,10 +62,5 @@ curl --location --globoff 'http://10.20.0.2:11010/v1/hypervisors/' \
 
 sudo systemctl restart netfilter-persistent.service
 
-# Make it unsafe but usable for newbies
-sudo passwd -u ubuntu
-echo "ubuntu:ubuntu" | sudo chpasswd
-sudo rm /etc/ssh/sshd_config.d/60-cloudimg-settings.conf
-
-#Do so only once
+#Do bootstrap only once
 sudo rm /etc/cron.d/core_bootstrap


### PR DESCRIPTION
It's already done in install.sh,
and because of that these commands fail
and make bootstrap.sh run on every reboot,
thus it wasn't persistent. Fix it just by removing them.