### PR TITLE
Restore the libvirt port-forward hook for dev stands, now for 80/443

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ Exposed on the node addresses by the control-plane `border` resource
 
 - `11010/tcp` — nested core API (proxied to `192.168.100.2:11010`)
 - `53/tcp+udp` — private DNS of the nested core (proxied to `192.168.100.2:5300`)
+- `80/tcp`, `443/tcp` — nested core LB, tenant HTTP/HTTPS ingress (proxied to
+  `192.168.100.2:80` / `192.168.100.2:443`)
 
 ## Requirements
 
@@ -98,12 +100,16 @@ Or simulate the managed flow by writing `/etc/exordos/realm_spec.json`
 yourself (see the contract in exordos_ecosystem `docs/realm-manager.md`) —
 the first-boot unit picks it up.
 
-Standalone there is no parent realm to deliver the `border` resource, so
-the nested core is **not** proxied onto the node addresses. Reach it
-directly from inside the stand (SSH in first):
+Standalone there is no parent realm to deliver the `border` resource, but
+`DEV_ACCESS=1` builds install a static libvirt hook
+(`etc/libvirt/hooks/qemu`) that forwards the nested core's LB (tenant
+HTTP/HTTPS ingress) onto the node addresses:
+
+- `80/tcp`, `443/tcp` — nested core LB (proxied to `192.168.100.2:80` /
+  `192.168.100.2:443`)
+
+The raw core API (`11010`) and private DNS (`53`) are not forwarded; reach
+those directly from inside the stand (SSH in first):
 
 - Core API: `http://192.168.100.2:11010`
 - Nested VM login: `ubuntu:ubuntu`
-
-(To expose it on the node's own address, add a forward yourself, e.g.
-`socat`/`iptables`, or deliver a realm spec so the managed flow runs.)

--- a/etc/libvirt/hooks/qemu
+++ b/etc/libvirt/hooks/qemu
@@ -1,0 +1,67 @@
+#!/bin/bash
+
+# Expose the nested core's LB (tenant HTTP/HTTPS ingress, ports 80/443) on
+# the node addresses. Only installed on DEV_ACCESS=1 (standalone developer
+# stand) builds: managed realm nodes get the same 80/443 forward from the
+# parent realm's `border` control-plane resource instead (see
+# exordos_ecosystem RealmInfra._create_border), so this hook would be
+# redundant there.
+#
+# The bootstrap domain is named `<prefix><uuid8>-exordos-core-bootstrap`
+# by the exordos CLI, hence the suffix match.
+
+case "${1}" in
+*exordos-core-bootstrap)
+
+    # Nested core address comes from the single source of truth written at
+    # build time (see exordos/images/install.sh); keeps this hook in sync
+    # with the bootstrap --cidr.
+    ENV_FILE=/etc/exordos/realm-image.env
+    # shellcheck source=/dev/null
+    [ -r "$ENV_FILE" ] && . "$ENV_FILE"
+    GUEST_IP=${NESTED_CORE_IP:-}
+    if [ -z "$GUEST_IP" ]; then
+        echo "libvirt hook: NESTED_CORE_IP not set ($ENV_FILE), skipping port forwarding" >&2
+        exit 0
+    fi
+
+    # External interface of the node (parent realm network side).
+    # jq is installed on the image; parse the default-route dev reliably
+    # instead of a positional awk field (breaks on gateway-less routes).
+    EXT_IF=$(ip -j route show default | jq -r '.[0].dev // empty')
+    if [ -z "$EXT_IF" ]; then
+        echo "libvirt hook: no default route interface, skipping port forwarding" >&2
+        exit 0
+    fi
+
+    forward() {
+        local proto=$1 host_port=$2 guest_port=$3 action=$4
+
+        # Always try to delete first to prevent duplicates and clean up cleanly
+        /sbin/iptables -D FORWARD -p $proto -d $GUEST_IP --dport $guest_port -j ACCEPT 2>/dev/null || true
+        /sbin/iptables -t nat -D PREROUTING -i $EXT_IF -p $proto --dport $host_port -j DNAT --to $GUEST_IP:$guest_port 2>/dev/null || true
+
+        if [ "$action" != "delete" ]; then
+            /sbin/iptables -I FORWARD 1 -p $proto -d $GUEST_IP --dport $guest_port -j ACCEPT
+            /sbin/iptables -t nat -I PREROUTING 1 -i $EXT_IF -p $proto --dport $host_port -j DNAT --to $GUEST_IP:$guest_port
+        fi
+    }
+
+    apply() {
+        local action=$1
+
+        # core LB (tenant HTTP/HTTPS ingress)
+        forward tcp 80 80 "$action"
+        forward tcp 443 443 "$action"
+    }
+
+    if [ "${2}" = "stopped" ] || [ "${2}" = "reconnect" ]; then
+        apply delete
+    fi
+    if [ "${2}" = "start" ] || [ "${2}" = "reconnect" ]; then
+        apply insert
+    fi
+
+    exit 0
+    ;;
+esac

--- a/exordos/images/exordos-realm-bootstrap.sh
+++ b/exordos/images/exordos-realm-bootstrap.sh
@@ -40,7 +40,7 @@ if [ -f "$MARKER" ]; then
 fi
 
 # Single source of truth for CORE_VERSION and the nested core network
-# (NESTED_CIDR / NESTED_GATEWAY), written at build time.
+# (NESTED_CIDR / NESTED_GATEWAY / NESTED_CORE_IP), written at build time.
 # The nested network is deliberately distinct from the parent realm network
 # (10.20.0.0/22) so it never collides on a nested realm node.
 # shellcheck source=/dev/null

--- a/exordos/images/install.sh
+++ b/exordos/images/install.sh
@@ -32,6 +32,7 @@ STORAGE_POOL_PATH="/var/lib/exordos-realm/disks"
 # collides when this node is itself a nested realm node.
 NESTED_CIDR="192.168.100.0/24"
 NESTED_GATEWAY="192.168.100.1"
+NESTED_CORE_IP="192.168.100.2"
 
 # Optimize apt
 echo 'APT::Install-Recommends "false";' | sudo tee -a /etc/apt/apt.conf.d/99exordos.conf > /dev/null
@@ -54,15 +55,23 @@ sudo apt-get install -y \
     qemu-system-modules-spice \
     iptables-persistent
 
-# Developer builds only: enable console/ssh password access.
-# Do NOT set for published images: access to managed realm nodes is
-# governed by the parent core (ssh key / user capabilities).
+# Developer builds only: enable console/ssh password access, and expose the
+# nested core's LB (ports 80/443) on the node addresses via a libvirt hook.
+# Do NOT set for published images: on managed realm nodes, access is
+# governed by the parent core (ssh key / user capabilities) and 80/443 are
+# already forwarded by the control-plane `border` resource the parent realm
+# delivers — a static hook there would be redundant.
 if [ "${DEV_ACCESS:-0}" = "1" ]; then
     echo "ubuntu:ubuntu" | sudo chpasswd
     sudo rm -f /etc/ssh/sshd_config.d/60-cloudimg-settings.conf
     # Unlock the default user's password. cloud.cfg ships "lock_passwd: True";
     # sed avoids pulling in yq just for this one line.
     sudo sed -i -E 's/(lock_passwd:[[:space:]]*)([Tt]rue)/\1false/' /etc/cloud/cloud.cfg
+
+    # iptables rules are order-sensitive, so set them via a libvirt hook.
+    sudo mkdir -p /etc/libvirt/hooks
+    sudo cp "$EL_PATH/etc/libvirt/hooks/qemu" /etc/libvirt/hooks/
+    sudo chmod +x /etc/libvirt/hooks/qemu
 fi
 
 # RAM/swap optimizations: the node hosts a nested core VM.
@@ -108,14 +117,12 @@ sudo virsh pool-define-as --name "$STORAGE_POOL" --type dir --target "$STORAGE_P
 sudo virsh pool-start "$STORAGE_POOL"
 sudo virsh pool-autostart "$STORAGE_POOL"
 
-# Exposing the nested core (core API 11010, private DNS 53) on the node
-# addresses and SNAT'ing the nested subnet out is done by the control-plane
+# On managed realm nodes, SNAT'ing the nested subnet out (and forwarding
+# 11010/53/80/443 onto the node addresses) is done by the control-plane
 # `border` resource (border_node capability) that the parent realm delivers
-# once the node registers — no static libvirt hook needed.
-#
-# The border driver (BorderCapabilityDriver) ships in gcl_sdk. Upgrade the
-# universal agent's gcl_sdk to the latest PyPI release so border support is
-# picked up automatically once released there.
+# once the node registers. The border driver (BorderCapabilityDriver) ships
+# in gcl_sdk. Upgrade the universal agent's gcl_sdk to the latest PyPI
+# release so border support is picked up automatically once released there.
 # GCL_SDK_WHEEL_URL overrides the install source (e.g. a wheel built from a
 # local gcl_sdk checkout and served from the dev repo) to test an unreleased
 # SDK build before it ships to PyPI.
@@ -172,6 +179,7 @@ CORE_VERSION=$CORE_VERSION
 ELEMENT_REPOSITORY=$ELEMENT_REPOSITORY
 NESTED_CIDR=$NESTED_CIDR
 NESTED_GATEWAY=$NESTED_GATEWAY
+NESTED_CORE_IP=$NESTED_CORE_IP
 EOL
 sudo chmod +x "$EL_PATH/exordos/images/exordos-realm-bootstrap.sh"
 sudo cp "$EL_PATH/etc/systemd/exordos-realm-bootstrap.service" /etc/systemd/system/


### PR DESCRIPTION
Standalone DEV_ACCESS=1 builds have no parent realm to deliver the border resource, so they were left with nothing proxied onto the node addresses. Reinstate the libvirt hook, but forward 80/443 (the nested core's LB / tenant HTTP(S) ingress) instead of the old 11010/53, and only install it on DEV_ACCESS builds — managed nodes already get 80/443 (plus 11010/53) from the border resource, so a static hook there would be redundant.